### PR TITLE
Add auto2top - reset scroll on page navigation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,6 +24,7 @@
       coverpage: false,
       loadSidebar: true,
       ga: 'UA-170034126-1',
+      auto2top: true,
       plugins: [
         EditOnGithubPlugin.create(
           'https://github.com/BRIKEV/express-jsdoc-swagger-docs/edit/master/docs/',


### PR DESCRIPTION
Hello good people!

Just a little thing I noticed... When you navigate from page to page the scroll position is not reset to top 0. So, say you scroll to the very bottom of the page, then navigate to another one. New page opens, but scroll is in the same position as it was on the previous page, somewhere in the bottom.

This little fix should make it reset the scroll position to the very top on every navigation.

https://docsify.js.org/#/configuration?id=auto2top

Feel free to close if the way it is now is the way you want it. Thank you!